### PR TITLE
Shared library location

### DIFF
--- a/Sources/HostBox/Application.cs
+++ b/Sources/HostBox/Application.cs
@@ -152,7 +152,7 @@ namespace HostBox
                         typeof(Borderline.IConfiguration),
                         typeof(DependencyContext)
                     },
-                Path.Combine("..", "shared", "libraries"));
+                this.ComponentConfig.SharedLibraryPath);
 
             var entryAssemblyName = loader.LoadDefaultAssembly().GetName(false);
 

--- a/Sources/HostBox/ComponentConfig.cs
+++ b/Sources/HostBox/ComponentConfig.cs
@@ -18,6 +18,11 @@ namespace HostBox
         /// Gets or sets path to domain binaries.
         /// </summary>
         public string Path { get; set; }
+        
+        /// <summary>
+        /// Gets or sets path to shared libraries binaries.
+        /// </summary>
+        public string SharedLibraryPath { get; set; }
 
         /// <summary>
         /// Gets or sets logger factory function.

--- a/Sources/HostBox/Configuration/SharedLibraryConfigurationExtensions.cs
+++ b/Sources/HostBox/Configuration/SharedLibraryConfigurationExtensions.cs
@@ -9,11 +9,14 @@ namespace HostBox.Configuration
 {
     public static class SharedLibraryConfigurationExtensions
     {
-        public static void LoadSharedLibraryConfigurationFiles(this IConfigurationBuilder builder, ILog logger, string componentBasePath)
+        public static void LoadSharedLibraryConfigurationFiles(this IConfigurationBuilder builder, ILog logger, string componentBasePath, string sharedLibraryPath)
         {
-            var sharedLibrariesPath = Path.Combine(componentBasePath, "..", "shared", "libraries");
+            var sharedLibrariesPath = Path.Combine(componentBasePath, sharedLibraryPath);
+            
+            bool directoryExists = Directory.Exists(sharedLibrariesPath); //var e = new DirectoryInfo(sharedLibrariesPath).Exists;
+            logger.Info(m => m($"Is shared library directory exists? -- {directoryExists}"));
 
-            if (Directory.Exists(sharedLibrariesPath))
+            if (directoryExists)
             {
                 var files = Directory.GetFiles(sharedLibrariesPath, "*.settings.json");
 

--- a/Sources/HostBox/Program.cs
+++ b/Sources/HostBox/Program.cs
@@ -62,7 +62,7 @@ namespace HostBox
 
                             Logger.Info(m => m("Application was launched with configuration '{0}'.", configName));
 
-                            config.LoadSharedLibraryConfigurationFiles(Logger, componentBasePath);
+                            config.LoadSharedLibraryConfigurationFiles(Logger, componentBasePath, commandLineArgs.SharedLibrariesPath);
 
                             var configProvider = new ConfigFileNamesProvider(configName, componentBasePath);
 
@@ -147,9 +147,10 @@ namespace HostBox
                 "Pattern of placeholders to find and replace into the component configuration (default is '!{*}')",
                 CommandOptionType.SingleValue);
 
+            var defaultSharedPath = Path.Combine("..", "shared", "libraries");
             var sharedOpt = cmdLnApp.Option(
                 "--shared-store-path",
-                "Directory path where additional dll dependencies located (resolved under component directory, default is 'shared')",
+                $"Directory path where additional dll dependencies located (resolved under component directory, default is '{defaultSharedPath}')",
                 CommandOptionType.SingleValue);
 
             cmdLnApp.VersionOption("-v|--version", cmdLnApp.ShortVersionGetter, cmdLnApp.LongVersionGetter);
@@ -171,7 +172,7 @@ namespace HostBox
 
                         if (!sharedOpt.HasValue())
                         {
-                            sharedOpt.Values.Add("shared");
+                            sharedOpt.Values.Add(defaultSharedPath);
                         }
 
                         return 0;

--- a/Sources/HostBox/Program.cs
+++ b/Sources/HostBox/Program.cs
@@ -95,6 +95,7 @@ namespace HostBox
                                 .AddSingleton(provider => new ComponentConfig
                                 {
                                     Path = componentPath,
+                                    SharedLibraryPath = commandLineArgs.SharedLibrariesPath,
                                     LoggerFactory = LogManager.GetLogger
                                 });
 

--- a/Sources/HostBox/Program.cs
+++ b/Sources/HostBox/Program.cs
@@ -147,7 +147,7 @@ namespace HostBox
                 "Pattern of placeholders to find and replace into the component configuration (default is '!{*}')",
                 CommandOptionType.SingleValue);
 
-            var defaultSharedPath = Path.Combine("..", "shared", "libraries");
+            var defaultSharedPath =  Environment.GetEnvironmentVariable("SHARED_STORE_PATH") ?? Path.Combine("..", "shared", "libraries");
             var sharedOpt = cmdLnApp.Option(
                 "--shared-store-path",
                 $"Directory path where additional dll dependencies located (resolved under component directory, default is '{defaultSharedPath}')",


### PR DESCRIPTION
Исправлена работа параметра командной строки "--shared-store-path", что позволяет управлять расположением источника общих библиотек