### PR TITLE
Переименован ранее не работавший параметр командной строки "--shared-store-path" в "--shared-libraries-path" 

### DIFF
--- a/Sources/HostBox/Program.cs
+++ b/Sources/HostBox/Program.cs
@@ -148,9 +148,9 @@ namespace HostBox
                 "Pattern of placeholders to find and replace into the component configuration (default is '!{*}')",
                 CommandOptionType.SingleValue);
 
-            var defaultSharedPath =  Environment.GetEnvironmentVariable("SHARED_STORE_PATH") ?? Path.Combine("..", "shared", "libraries");
+            var defaultSharedPath =  Environment.GetEnvironmentVariable("SHARED_LIBRARIES_PATH") ?? Path.Combine("..", "shared", "libraries");
             var sharedOpt = cmdLnApp.Option(
-                "--shared-store-path",
+                "--shared-libraries-path",
                 $"Directory path where additional dll dependencies located (resolved under component directory, default is '{defaultSharedPath}')",
                 CommandOptionType.SingleValue);
 


### PR DESCRIPTION
Переименован параметр командной строки "--shared-store-path" в "--shared-libraries-path" и переменная окружения "SHARED_STORE_PATH" в "SHARED_LIBRARIES_PATH" 