### PR TITLE
Allow ReadWrite file share for reading NLog configuration

### DIFF
--- a/Sources/HostBox/Logging/NLogLoggerFactoryAdapter.cs
+++ b/Sources/HostBox/Logging/NLogLoggerFactoryAdapter.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.IO;
-
+using System.Xml;
 using Common.Logging;
 using Common.Logging.Configuration;
 using Common.Logging.Factory;
+using NLog.Config;
 
 namespace HostBox.Logging
 {
@@ -49,10 +50,19 @@ namespace HostBox.Logging
                 case "INLINE":
                     break;
                 case "FILE":
-                    global::NLog.LogManager.Configuration = new global::NLog.Config.XmlLoggingConfiguration(configFile);
+                    global::NLog.LogManager.Configuration = GetConfiguration(configFile);
                     break;
                 default:
                     break;
+            }
+        }
+
+        private static XmlLoggingConfiguration GetConfiguration(string configFile)
+        {
+            var fileStream = new FileStream(configFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, 1);
+            using (var reader = XmlReader.Create(fileStream))
+            {
+                return new global::NLog.Config.XmlLoggingConfiguration(reader);
             }
         }
 


### PR DESCRIPTION
При старте сервисов в докере достаточно часто начали сталкиваться с отказом одного из сервисов (F.S.Manager):

> Произошла ошибка Common.Logging.ConfigurationException: Unable to create instance of type Gems.Hosting.Bootstrapper.Logging.NLogLoggerFactoryAdapter. Possible explanation is lack of zero arg and single arg Common.Logging.Configuration.NameValueCollection constructors ---> System.IO.IOException: The process cannot access the file '/app/build/settings/nlog.config' because it is being used by another process.

При копировании файлов конфигурации на шару, один инстанс сеттингов шарится между 2мя инстансами приложения (при использовании именованых инстансов). 

Есть гипотеза, что копирование на шару совпадает с моментом чтения при старте сервиса.

Предлагается разрешить ReadWrite мод для чтения конфига, чтобы избежать подобного фэйла на старте сервиса. 
