### PR TITLE
hostbox should be crash when the HostableComponent throw an exception during initialization

### DIFF
--- a/Sources/HostBox/HostableComponentsFinalizer.cs
+++ b/Sources/HostBox/HostableComponentsFinalizer.cs
@@ -12,7 +12,7 @@ namespace HostBox
 {
     public class HostableComponentsFinalizer : IHostedService
     {
-        private readonly HostedComponentsManager hostedComponentsManager;
+        private readonly ComponentsRunner componentsRunner;
 
         private readonly HostComponentsConfiguration configuration;
 
@@ -24,13 +24,13 @@ namespace HostBox
 #endif
 
 #if NETCOREAPP3_1_OR_GREATER
-        public HostableComponentsFinalizer(IHostApplicationLifetime lifetime, HostedComponentsManager hostedComponentsManager, HostComponentsConfiguration configuration)
+        public HostableComponentsFinalizer(IHostApplicationLifetime lifetime, ComponentsRunner componentsRunner, HostComponentsConfiguration configuration)
 #else
         public HostableComponentsFinalizer(IApplicationLifetime lifetime, HostedComponentsManager hostedComponentsManager, HostComponentsConfiguration configuration)
 #endif
         {
             this.lifetime = lifetime;
-            this.hostedComponentsManager = hostedComponentsManager;
+            this.componentsRunner = componentsRunner;
             this.configuration = configuration;
         }
 
@@ -40,7 +40,7 @@ namespace HostBox
                 () =>
                     {
                         var cts = new CancellationTokenSource(this.configuration.StoppingTimeout);
-                        var stopTasks = this.hostedComponentsManager.GetComponents()
+                        var stopTasks = this.componentsRunner.GetComponents()
                             .Select(x => Task.Run(() => x.Stop(), cts.Token));
                         Task.WaitAll(stopTasks.ToArray());
                     });

--- a/Sources/HostBox/Loading/HostedComponentsManager.cs
+++ b/Sources/HostBox/Loading/HostedComponentsManager.cs
@@ -1,14 +1,16 @@
 ﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 
 using HostBox.Borderline;
 
 namespace HostBox.Loading
 {
-    public class HostedComponentsManager
+    public class ComponentsRunner
     {
         private readonly List<IHostableComponent> components = new List<IHostableComponent>();
 
-        public HostedComponentsManager(IEnumerable<IHostableComponent> components)
+        public ComponentsRunner(IEnumerable<IHostableComponent> components)
         {
             this.AddComponents(components);
         }
@@ -23,5 +25,20 @@ namespace HostBox.Loading
 
         public IEnumerable<IHostableComponent> GetComponents() =>
             this.components.ToArray();
+
+        public Task RunComponents(CancellationToken cancellationToken)
+        {
+            return Task.Factory.StartNew(
+                () =>
+                    {
+                        foreach (var component in components)
+                        {
+                            component.Start(); // TODO: should pass the cancellationToken
+                        }
+                    },
+                cancellationToken,
+                TaskCreationOptions.LongRunning,
+                TaskScheduler.Default);
+        }
     }
 }

--- a/Sources/HostBox/Loading/HostedComponentsManager.cs
+++ b/Sources/HostBox/Loading/HostedComponentsManager.cs
@@ -6,11 +6,11 @@ using HostBox.Borderline;
 
 namespace HostBox.Loading
 {
-    public class ComponentsRunner
+    public class HostedComponentsManager
     {
         private readonly List<IHostableComponent> components = new List<IHostableComponent>();
 
-        public ComponentsRunner(IEnumerable<IHostableComponent> components)
+        public HostedComponentsManager(IEnumerable<IHostableComponent> components)
         {
             this.AddComponents(components);
         }

--- a/Sources/HostBox/Program.cs
+++ b/Sources/HostBox/Program.cs
@@ -43,9 +43,9 @@ namespace HostBox
                     var host = CreateHostBuilder(commandLineArgs)
                         .Build();
 
-                    var runner = host.Services.GetService<ComponentsRunner>();
+                    var manager = host.Services.GetService<HostedComponentsManager>();
 
-                    await runner.RunComponents(CancellationToken.None);
+                    await manager.RunComponents(CancellationToken.None);
 
                     await host.RunAsync();
                 }
@@ -127,7 +127,7 @@ namespace HostBox
                         services.AddSingleton(ctx.Configuration.GetSection("host:components").Get<HostComponentsConfiguration>()
                                               ?? new HostComponentsConfiguration());
 
-                        services.AddSingleton(new ComponentsRunner(loadComponentsResult.Components));
+                        services.AddSingleton(new HostedComponentsManager(loadComponentsResult.Components));
 
                         services.AddHostedService<HostableComponentsFinalizer>();
                         services.AddHostedService<ApplicationLifetimeLogger>();

--- a/Sources/HostBox/Program.cs
+++ b/Sources/HostBox/Program.cs
@@ -40,9 +40,14 @@ namespace HostBox
 
                 if (commandLineArgs.CommandLineArgsValid)
                 {
-                    await CreateHostBuilder(commandLineArgs)
-                        .Build()
-                        .RunAsync();
+                    var host = CreateHostBuilder(commandLineArgs)
+                        .Build();
+
+                    var runner = host.Services.GetService<ComponentsRunner>();
+
+                    await runner.RunComponents(CancellationToken.None);
+
+                    await host.RunAsync();
                 }
             }
             catch (Exception ex)
@@ -98,17 +103,17 @@ namespace HostBox
                     {
                         Directory.SetCurrentDirectory(Path.GetDirectoryName(componentPath));
 
-                        var loadAndRunComponentsResult = new ComponentsLoader(
+                        var loadComponentsResult = new ComponentsLoader(
                             new ComponentConfig
-                            {
-                                Path = componentPath,
-                                SharedLibraryPath = commandLineArgs.SharedLibrariesPath
-                            }).LoadAndRunComponents(ctx.Configuration, CancellationToken.None);
-                        
+                                {
+                                    Path = componentPath,
+                                    SharedLibraryPath = commandLineArgs.SharedLibrariesPath
+                                }).LoadComponents(ctx.Configuration);
+
 #if !NETCOREAPP2_1
                         if (commandLineArgs.Web)
                         {
-                            var startup = loadAndRunComponentsResult?.EntryAssembly?.GetExportedTypes().FirstOrDefault(t => typeof(IStartup).IsAssignableFrom(t));
+                            var startup = loadComponentsResult?.EntryAssembly?.GetExportedTypes().FirstOrDefault(t => typeof(IStartup).IsAssignableFrom(t));
                             if (startup != null)
                             {
                                 services.AddSingleton(typeof(IStartup), startup);
@@ -122,7 +127,7 @@ namespace HostBox
                         services.AddSingleton(ctx.Configuration.GetSection("host:components").Get<HostComponentsConfiguration>()
                                               ?? new HostComponentsConfiguration());
 
-                        services.AddSingleton(new HostedComponentsManager(loadAndRunComponentsResult.Components));
+                        services.AddSingleton(new ComponentsRunner(loadComponentsResult.Components));
 
                         services.AddHostedService<HostableComponentsFinalizer>();
                         services.AddHostedService<ApplicationLifetimeLogger>();


### PR DESCRIPTION
When the hostable component throw an error during initialization the hostbox log error and hung up. It happens because the task   running the HostableComponents list are not awaiting. The hostbox will crashed only if GC will collect the Task that contains an exception inside.